### PR TITLE
Use CSV as default output encoding

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -21,12 +21,14 @@ import (
 	"log"
 	"os"
 
+	"github.com/booster-proj/lsaddr/encoder"
 	"github.com/booster-proj/lsaddr/lookup"
 	"github.com/spf13/cobra"
 )
 
 var Logger = log.New(os.Stderr, "[lsaddr] ", 0)
 var debug bool
+var csv bool
 
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{
@@ -49,12 +51,18 @@ var rootCmd = &cobra.Command{
 		}
 		Logger.Printf("# of open files: %d", len(onf))
 
+		filtered := make([]lookup.NetFile, 0, len(onf))
 		for _, v := range onf {
 			if v.Dst.String() == "" {
 				Logger.Printf("skipping open file: %v", v)
 				continue
 			}
-			fmt.Fprintf(os.Stdout, "%v\n", v)
+			filtered = append(filtered, v)
+		}
+
+		if err := encoder.NewCSV(os.Stdout).Encode(filtered); err != nil {
+			Logger.Printf("unable to encode open network files: %v\n", s, err)
+			os.Exit(1)
 		}
 	},
 }
@@ -70,6 +78,7 @@ func Execute() {
 
 func init() {
 	rootCmd.PersistentFlags().BoolVarP(&debug, "debug", "", false, "print debug information to stderr")
+	rootCmd.Flags().BoolVarP(&csv, "csv", "", true, "enable csv output encoding")
 }
 
 const usage = `

--- a/encoder/csv.go
+++ b/encoder/csv.go
@@ -1,0 +1,50 @@
+// Copyright © 2019 booster authors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+package encoder
+
+import (
+	"encoding/csv"
+	"io"
+
+	"github.com/booster-proj/lsaddr/lookup"
+)
+
+type csvEncoder struct {
+	w *csv.Writer
+}
+
+func newCSVEncoder(w io.Writer) *csvEncoder {
+	return &csvEncoder{
+		w: csv.NewWriter(w),
+	}
+}
+
+func (e *csvEncoder) Encode(l []lookup.NetFile) error {
+	header := []string{"COMMAND", "NET", "SRC", "DST"}
+	if err := e.w.Write(header); err != nil {
+		return err
+	}
+
+	for _, v := range l {
+		record := []string{v.Command, v.Src.Network(), v.Src.String(), v.Dst.String()}
+		if err := e.w.Write(record); err != nil {
+			return err
+		}
+	}
+
+	e.w.Flush()
+	return e.w.Error()
+}

--- a/encoder/csv_test.go
+++ b/encoder/csv_test.go
@@ -1,0 +1,24 @@
+// Copyright © 2019 booster authors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+package encoder_test
+
+import (
+	"testing"
+)
+
+func TestEncodeCSV(t *testing.T) {
+	// TODO: test test test
+}

--- a/encoder/csv_test.go
+++ b/encoder/csv_test.go
@@ -16,9 +16,39 @@
 package encoder_test
 
 import (
+	"net"
+	"strings"
 	"testing"
+
+	"github.com/booster-proj/lsaddr/encoder"
+	"github.com/booster-proj/lsaddr/lookup"
 )
 
-func TestEncodeCSV(t *testing.T) {
+func TestEncode_CSV(t *testing.T) {
 	// TODO: test test test
+	l := []lookup.NetFile{
+		{"foo", newUDPAddr("192.168.0.61:54104"), newUDPAddr("52.94.218.7:443")},
+		{"bar", newUDPAddr("[::1]:60051"), newUDPAddr("[::1]:60051")},
+	}
+
+	var w strings.Builder
+	if err := encoder.NewCSV(&w).Encode(l); err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	expOut := `COMMAND,NET,SRC,DST
+foo,udp,192.168.0.61:54104,52.94.218.7:443
+bar,udp,[::1]:60051,[::1]:60051
+`
+	if expOut != w.String() {
+		t.Fatalf("Unexpected output: wanted \"%s\", found \"%s\"", expOut, w.String())
+	}
+}
+
+func newUDPAddr(address string) net.Addr {
+	addr, err := net.ResolveUDPAddr("udp", address)
+	if err != nil {
+		panic(err)
+	}
+	return addr
 }

--- a/encoder/net_file.go
+++ b/encoder/net_file.go
@@ -21,10 +21,13 @@ import (
 	"github.com/booster-proj/lsaddr/lookup"
 )
 
+// Encoder is a wrapper around the Encode function.
 type Encoder interface {
 	Encode([]lookup.NetFile) error
 }
 
+// NewCSV returns an Encoder implementation which encodes
+// in CSV format.
 func NewCSV(w io.Writer) Encoder {
 	return newCSVEncoder(w)
 }

--- a/encoder/net_file.go
+++ b/encoder/net_file.go
@@ -1,0 +1,30 @@
+// Copyright © 2019 booster authors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+package encoder
+
+import (
+	"io"
+
+	"github.com/booster-proj/lsaddr/lookup"
+)
+
+type Encoder interface {
+	Encode([]lookup.NetFile) error
+}
+
+func NewCSV(w io.Writer) Encoder {
+	return newCSVEncoder(w)
+}


### PR DESCRIPTION
Close #2.

## API changes
A new `encoder` module has been added

## General changes
Now CSV is the default output encoding