### PR TITLE
Add bpf output encoder

### DIFF
--- a/encoder/bpf.go
+++ b/encoder/bpf.go
@@ -23,7 +23,8 @@ import (
 	"github.com/booster-proj/lsaddr/lookup"
 )
 
-// TODO: doc
+// Flags used to configure which `lookup.NetFile` fields the encoder
+// will use to encode the filter.
 const (
 	Fdst = 1 << iota
 	Fsrc
@@ -31,7 +32,9 @@ const (
 	FstdFields = Fdst | Fsrc | Fport // initial values for standard encoder
 )
 
-// TODO: doc
+// BPFEncoder is an Encoder implementation which encodes `lookup.NetFiles`
+// using the BPF format.
+// The "Fields" field can be used to configure how the filter is composed.
 type BPFEncoder struct {
 	w      io.Writer
 	Fields int
@@ -43,7 +46,7 @@ func newBPFEncoder(w io.Writer) *BPFEncoder {
 	}
 }
 
-// TODO: doc
+// Encode encodes "l" into a bpf. A new line is added at the end.
 func (e *BPFEncoder) Encode(l []lookup.NetFile) error {
 	if e.Fields == 0 {
 		e.Fields = FstdFields

--- a/encoder/bpf.go
+++ b/encoder/bpf.go
@@ -104,7 +104,7 @@ func (e *bpfBuilder) buildAddr(addr string, fields int) (string, error) {
 
 	l = append(l, "host", host)
 	if fields&Fport != 0 {
-		l = append(l, "port", port)
+		l = append(l, "and", "port", port)
 	}
 	return strings.Join(l, " "), nil
 }

--- a/encoder/bpf.go
+++ b/encoder/bpf.go
@@ -1,0 +1,107 @@
+// Copyright © 2019 booster authors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+package encoder
+
+import (
+	"io"
+	"net"
+	"strings"
+
+	"github.com/booster-proj/lsaddr/lookup"
+)
+
+// TODO: doc
+const (
+	Fdst = 1 << iota
+	Fsrc
+	Fport
+	FstdFields = Fdst | Fsrc | Fport // initial values for standard encoder
+)
+
+// TODO: doc
+type BPFEncoder struct {
+	w      io.Writer
+	Fields int
+}
+
+func newBPFEncoder(w io.Writer) *BPFEncoder {
+	return &BPFEncoder{
+		w: w,
+	}
+}
+
+// TODO: doc
+func (e *BPFEncoder) Encode(l []lookup.NetFile) error {
+	if e.Fields == 0 {
+		e.Fields = FstdFields
+	}
+
+	var builder bpfBuilder
+	for _, v := range l {
+		if err := builder.Or(v, e.Fields); err != nil {
+			return err
+		}
+	}
+	r := strings.NewReader(builder.b.String() + "\n")
+	_, err := io.Copy(e.w, r)
+	return err
+}
+
+type bpfBuilder struct {
+	b strings.Builder
+}
+
+func (b *bpfBuilder) Or(f lookup.NetFile, fields int) error {
+	l := []string{}
+	if (fields & Fsrc) != 0 {
+		i, err := b.buildAddr(f.Src.String(), fields)
+		if err != nil {
+			return err
+		}
+		l = append(l, i)
+	}
+	if (fields & Fdst) != 0 {
+		i, err := b.buildAddr(f.Dst.String(), fields)
+		if err != nil {
+			return err
+		}
+		l = append(l, i)
+	}
+
+	cur := strings.Join(l, " or ")
+	prev := b.b.String()
+	if prev != "" {
+		cur = strings.Join([]string{prev, cur}, " or ")
+	}
+
+	b.b.Reset()
+	_, err := b.b.Write([]byte(cur))
+	return err
+}
+
+func (e *bpfBuilder) buildAddr(addr string, fields int) (string, error) {
+	l := []string{}
+	host, port, err := net.SplitHostPort(addr)
+	if err != nil {
+		return "", err
+	}
+
+	l = append(l, "host", host)
+	if fields&Fport != 0 {
+		l = append(l, "port", port)
+	}
+	return strings.Join(l, " "), nil
+}

--- a/encoder/bpf_test.go
+++ b/encoder/bpf_test.go
@@ -13,38 +13,24 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-package encoder
+package encoder_test
 
 import (
-	"encoding/csv"
-	"io"
+	"strings"
+	"testing"
 
-	"github.com/booster-proj/lsaddr/lookup"
+	"github.com/booster-proj/lsaddr/encoder"
 )
 
-type CSVEncoder struct {
-	w *csv.Writer
-}
-
-func newCSVEncoder(w io.Writer) *CSVEncoder {
-	return &CSVEncoder{
-		w: csv.NewWriter(w),
-	}
-}
-
-func (e *CSVEncoder) Encode(l []lookup.NetFile) error {
-	header := []string{"COMMAND", "NET", "SRC", "DST"}
-	if err := e.w.Write(header); err != nil {
-		return err
+func TestEncode_BPF(t *testing.T) {
+	l := netFiles0
+	var w strings.Builder
+	if err := encoder.NewBPF(&w).Encode(l); err != nil {
+		t.Fatalf("Unexpected error: %v", err)
 	}
 
-	for _, v := range l {
-		record := []string{v.Command, v.Src.Network(), v.Src.String(), v.Dst.String()}
-		if err := e.w.Write(record); err != nil {
-			return err
-		}
+	expOut := "host 192.168.0.61 port 54104 or host 52.94.218.7 port 443 or host ::1 port 60051 or host ::1 port 60052\n"
+	if expOut != w.String() {
+		t.Fatalf("Unexpected output: wanted \"%s\", found \"%s\"", expOut, w.String())
 	}
-
-	e.w.Flush()
-	return e.w.Error()
 }

--- a/encoder/bpf_test.go
+++ b/encoder/bpf_test.go
@@ -29,7 +29,7 @@ func TestEncode_BPF(t *testing.T) {
 		t.Fatalf("Unexpected error: %v", err)
 	}
 
-	expOut := "host 192.168.0.61 port 54104 or host 52.94.218.7 port 443 or host ::1 port 60051 or host ::1 port 60052\n"
+	expOut := "host 192.168.0.61 and port 54104 or host 52.94.218.7 and port 443 or host ::1 and port 60051 or host ::1 and port 60052\n"
 	if expOut != w.String() {
 		t.Fatalf("Unexpected output: wanted \"%s\", found \"%s\"", expOut, w.String())
 	}

--- a/encoder/csv_test.go
+++ b/encoder/csv_test.go
@@ -16,21 +16,14 @@
 package encoder_test
 
 import (
-	"net"
 	"strings"
 	"testing"
 
 	"github.com/booster-proj/lsaddr/encoder"
-	"github.com/booster-proj/lsaddr/lookup"
 )
 
 func TestEncode_CSV(t *testing.T) {
-	// TODO: test test test
-	l := []lookup.NetFile{
-		{"foo", newUDPAddr("192.168.0.61:54104"), newUDPAddr("52.94.218.7:443")},
-		{"bar", newUDPAddr("[::1]:60051"), newUDPAddr("[::1]:60051")},
-	}
-
+	l := netFiles0
 	var w strings.Builder
 	if err := encoder.NewCSV(&w).Encode(l); err != nil {
 		t.Fatalf("Unexpected error: %v", err)
@@ -38,17 +31,9 @@ func TestEncode_CSV(t *testing.T) {
 
 	expOut := `COMMAND,NET,SRC,DST
 foo,udp,192.168.0.61:54104,52.94.218.7:443
-bar,udp,[::1]:60051,[::1]:60051
+bar,udp,[::1]:60051,[::1]:60052
 `
 	if expOut != w.String() {
 		t.Fatalf("Unexpected output: wanted \"%s\", found \"%s\"", expOut, w.String())
 	}
-}
-
-func newUDPAddr(address string) net.Addr {
-	addr, err := net.ResolveUDPAddr("udp", address)
-	if err != nil {
-		panic(err)
-	}
-	return addr
 }

--- a/encoder/encoder_test.go
+++ b/encoder/encoder_test.go
@@ -13,21 +13,23 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-package encoder
+package encoder_test
 
 import (
-	"io"
+	"net"
 
 	"github.com/booster-proj/lsaddr/lookup"
 )
 
-// Encoder is a wrapper around the Encode function.
-type Encoder interface {
-	Encode([]lookup.NetFile) error
+var netFiles0 = []lookup.NetFile{
+	{"foo", newUDPAddr("192.168.0.61:54104"), newUDPAddr("52.94.218.7:443")},
+	{"bar", newUDPAddr("[::1]:60051"), newUDPAddr("[::1]:60052")},
 }
 
-// NewCSV returns an Encoder implementation which encodes
-// in CSV format.
-func NewCSV(w io.Writer) Encoder {
-	return newCSVEncoder(w)
+func newUDPAddr(address string) net.Addr {
+	addr, err := net.ResolveUDPAddr("udp", address)
+	if err != nil {
+		panic(err)
+	}
+	return addr
 }


### PR DESCRIPTION
Make it possible to encode the output using either  `csv` or `bpf` encoding format.
Close #2 